### PR TITLE
Update overlay.rb for SV-261937

### DIFF
--- a/controls/overlay.rb
+++ b/controls/overlay.rb
@@ -1299,6 +1299,14 @@ control 'SV-261922' do
     end
   end
 
+  control 'SV-261937' do
+    sql = postgres_session(input('pg_dba'), input('pg_dba_password'), input('pg_host'), input('pg_port'))
+
+    describe sql.query('SHOW server_version;', [input('pg_db')]) do
+      its('output') { should cmp >= input('min_org_allowed_postgres_version') }
+    end
+  end
+
   control 'SV-261938' do
     describe 'Requires manual review of the RDS audit log system.' do
       skip 'Requires manual review of the RDS audit log system.'

--- a/controls/overlay.rb
+++ b/controls/overlay.rb
@@ -561,12 +561,12 @@ include_controls 'crunchy-data-postgresql-16-stig-baseline' do
       if database == 'postgres'
         schemas_sql = 'SELECT n.nspname, pg_catalog.pg_get_userbyid(n.nspowner) '\
           'FROM pg_catalog.pg_namespace n '\
-          "WHERE pg_catalog.pg_get_userbyid(n.nspowner) <> '#{pg_owner}' AND pg_catalog.pg_get_userbyid(n.nspowner) <> 'rdsadmin';"
+          "WHERE pg_catalog.pg_get_userbyid(n.nspowner) <> '#{pg_owner}' AND pg_catalog.pg_get_userbyid(n.nspowner) <> 'rdsadmin' AND pg_catalog.pg_get_userbyid(n.nspowner) <> 'pg_database_owner';"
         functions_sql = 'SELECT n.nspname, p.proname, '\
           'pg_catalog.pg_get_userbyid(n.nspowner) '\
           'FROM pg_catalog.pg_proc p '\
           'LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace '\
-          "WHERE pg_catalog.pg_get_userbyid(n.nspowner) <> '#{pg_owner}' AND pg_catalog.pg_get_userbyid(n.nspowner) <> 'rdsadmin';"
+          "WHERE pg_catalog.pg_get_userbyid(n.nspowner) <> '#{pg_owner}' AND pg_catalog.pg_get_userbyid(n.nspowner) <> 'rdsadmin' AND pg_catalog.pg_get_userbyid(n.nspowner) <> 'pg_database_owner';"
       else
         schemas_sql = 'SELECT n.nspname, pg_catalog.pg_get_userbyid(n.nspowner) '\
           'FROM pg_catalog.pg_namespace n '\

--- a/controls/overlay.rb
+++ b/controls/overlay.rb
@@ -999,12 +999,12 @@ include_controls 'crunchy-data-postgresql-16-stig-baseline' do
       if database == 'postgres'
         schemas_sql = 'SELECT n.nspname, pg_catalog.pg_get_userbyid(n.nspowner) '\
           'FROM pg_catalog.pg_namespace n '\
-          "WHERE pg_catalog.pg_get_userbyid(n.nspowner) <> '#{pg_owner}' AND pg_catalog.pg_get_userbyid(n.nspowner) <> 'rdsadmin';"
+          "WHERE pg_catalog.pg_get_userbyid(n.nspowner) <> '#{pg_owner}' AND pg_catalog.pg_get_userbyid(n.nspowner) <> 'rdsadmin' AND pg_catalog.pg_get_userbyid(n.nspowner) <> 'pg_database_owner';"
         functions_sql = 'SELECT n.nspname, p.proname, '\
           'pg_catalog.pg_get_userbyid(n.nspowner) '\
           'FROM pg_catalog.pg_proc p '\
           'LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace '\
-          "WHERE pg_catalog.pg_get_userbyid(n.nspowner) <> '#{pg_owner}' AND pg_catalog.pg_get_userbyid(n.nspowner) <> 'rdsadmin';"
+          "WHERE pg_catalog.pg_get_userbyid(n.nspowner) <> '#{pg_owner}' AND pg_catalog.pg_get_userbyid(n.nspowner) <> 'rdsadmin' AND pg_catalog.pg_get_userbyid(n.nspowner) <> 'pg_database_owner';"
       else
         schemas_sql = 'SELECT n.nspname, pg_catalog.pg_get_userbyid(n.nspowner) '\
           'FROM pg_catalog.pg_namespace n '\

--- a/controls/overlay.rb
+++ b/controls/overlay.rb
@@ -4,27 +4,15 @@ include_controls 'crunchy-data-postgresql-16-stig-baseline' do
   # Add libraries/ to the Ruby load path
   $LOAD_PATH.unshift File.expand_path('../libraries', __dir__)
 
-  # begin
-  #   require 'helper_methods'
-  #   CustomHelper::ESCAPE_LOOKUP  # ← This line raises NameError if CustomHelper or ESCAPE_LOOKUP isn't defined
-  # rescue LoadError, NameError
-  #   require_relative '../libraries/helper_methods'
-  # end
   CUSTOM_HELPER_LOADED = begin
     begin
-      puts "Loading custom helper using require 'helper_methods'"
       require 'helper_methods'
-      puts "Custom helper loaded successfully - Testing ESCAPE_LOOKUP"
       CustomHelper::ESCAPE_LOOKUP # ← This line raises NameError if CustomHelper or ESCAPE_LOOKUP isn't defined
-      puts "Custom helper ESCAPE_LOOKUP is available"
       true
     rescue LoadError, NameError
       begin
-        puts "Loading custom helper using require_relative '../libraries/helper_methods'"
         require_relative '../libraries/helper_methods'
-        puts "Custom helper loaded successfully - Testing ESCAPE_LOOKUP"
         CustomHelper::ESCAPE_LOOKUP # ← This line raises NameError if CustomHelper or ESCAPE_LOOKUP isn't defined
-        puts "Custom helper ESCAPE_LOOKUP is available"
         true
       rescue LoadError, NameError
         false


### PR DESCRIPTION
Adds overlay logic for SV-261937. Rather than psql --version, it uses SHOW server_version, querying directly into the server. The original STIG assumed a hosted instance, whereby the psql and server versions are stated, but the later won't state with an RDS instance - you'll only get the version of the psql binary on your InSpec runner.